### PR TITLE
Fix case where CFBundleDisplayName is null

### DIFF
--- a/Pod/Classes/CGLMediaPicker.m
+++ b/Pod/Classes/CGLMediaPicker.m
@@ -216,8 +216,15 @@ NSInteger const CGLMediaPickerTagPermissionDenied = 1002;
 
 // kudos to https://github.com/clusterinc/ClusterPrePermissions
 - (void)preRequestForAssetNamed:(NSString *)assetName message:(NSString *)message tag:(NSInteger)tag {
-    NSString *appName = [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
-
+    NSString *appName;
+    
+    id bundleDisplayName = [[NSBundle mainBundle] infoDictionary][@"CFBundleDisplayName"];
+    if (bundleDisplayName != nil) {
+        appName = bundleDisplayName;
+    } else {
+        appName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"];
+    }
+    
     NSString *title = [NSString stringWithFormat:@"Let %@ Access %@?", appName, assetName];
     
     UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:message delegate:self cancelButtonTitle:NSLocalizedString(@"Not Now", nil) otherButtonTitles:NSLocalizedString(@"Grant Access", nil), nil];


### PR DESCRIPTION
Based on [Apple's documentation](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/plist/info/CFBundleDisplayName), CFBundleDisplayName is optional, so it's not safe for one to assume it's defined. As a fallback we can check CFBundleName, which is guaranteed to be defined. This fixes the issue for me.
